### PR TITLE
Fix application crash on Windows OS

### DIFF
--- a/package.json
+++ b/package.json
@@ -237,7 +237,7 @@
     "webpack-hot-middleware": "^2.22.1",
     "webpack-manifest-plugin": "3.0.0-rc.0",
     "webpack-merge": "^4.2.1",
-    "webpack-notifier": "^1.8.0"
+    "webpack-notifier": "^1.13.0"
   },
   "resolutions": {
     "webpack-sources": "^2.1.1",

--- a/webpack/development.js
+++ b/webpack/development.js
@@ -4,19 +4,21 @@ const WebpackNotifierPlugin = require('webpack-notifier');
 const path = require('path');
 const common = require('./common.js');
 
+const cwd = process.cwd();
+
 module.exports = merge(common, {
   mode: 'development',
   devtool: 'cheap-module-source-map',
   entry: [
     'webpack-hot-middleware/client?overlay=false',
-    path.resolve(process.cwd(), 'src/client'),
+    path.resolve(cwd, 'src/client'),
   ],
   cache: { type: 'filesystem' },
   plugins: [
     new webpack.HotModuleReplacementPlugin(),
     new WebpackNotifierPlugin({
       excludeWarnings: true,
-      title: `${process.env.PWD.split('/').pop()}`,
+      title: cwd.split('/').pop(),
     }),
   ],
 });


### PR DESCRIPTION
This PR fixes the following:
- [x] Fix crash on Windows OS when trying to access PWD env (this would work only on Mac/Linux: [see](https://man7.org/linux/man-pages/man7/environ.7.html) the list of available env variables)
- [x] Update webpack notifier plugin for better compatibility with Windows OS.